### PR TITLE
Restore: Modal classNames

### DIFF
--- a/src/components/auth/login/Login.jsx
+++ b/src/components/auth/login/Login.jsx
@@ -36,24 +36,32 @@ const LogInForm = () => {
   };
 
   const emailGroup = (
-    <Form.Group controlId="formGroupEmail">
-      <Form.Label>Email address</Form.Label>
-      <Form.Control
-        type="email"
-        placeholder="Enter email"
-        onChange={(e) => setEmailValue(e.target.value)}
-      />
+    <Form.Group controlId="formGroupEmail" className="formGroupEmail">
+      <Form.Label className="formInputLabel">Email address</Form.Label>
+      <div className="formInputWrapper">
+        <i className="fas fa-user-circle"></i>
+        <Form.Control
+          type="email"
+          placeholder="Enter email"
+          className="formInput"
+          onChange={(e) => setEmailValue(e.target.value)}
+        />
+      </div>
     </Form.Group>
   );
 
   const passwordGroup = (
     <Form.Group controlId="formGroupPassword">
       <Form.Label>Password</Form.Label>
-      <Form.Control
-        type="password"
-        placeholder="Password"
-        onChange={(e) => setPasswordValue(e.target.value)}
-      />
+      <div className="formInputWrapper">
+        <i className="fas fa-key"></i>
+        <Form.Control
+          type="password"
+          placeholder="Enter your password"
+          className="formInput"
+          onChange={(e) => setPasswordValue(e.target.value)}
+        />
+      </div>
     </Form.Group>
   );
 


### PR DESCRIPTION
Hey Louis!

It seems like we mistakenly deleted a few `className` during merging so some styling in modal is lost. I restored classNames in [this ](https://github.com/ReCoded-Org/istanbul-capstone-ecommerce/pull/49)PR.

Please let me know if anythings is wrong.