### PR TITLE
Bug fix #2: About page

### DIFF
--- a/debug.log
+++ b/debug.log
@@ -1,1 +1,0 @@
-[0818/002306.257:ERROR:crash_report_database_win.cc(469)] failed to stat report

--- a/src/components/about/About.jsx
+++ b/src/components/about/About.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import AboutHeader from "./AboutHeader";
 import OurTeam from "./OurTeam";
-import Footer from "../layout/footer/Footer";
 import "./style.scss";
 
 export default function About() {
@@ -9,7 +8,6 @@ export default function About() {
     <div className="aboutPage">
       <AboutHeader />
       <OurTeam />
-      <Footer />
     </div>
   );
 }

--- a/src/components/about/style.scss
+++ b/src/components/about/style.scss
@@ -61,6 +61,7 @@
 .ourTeamContainer {
   width: 100%;
   height: 100%;
+  padding-bottom: 100px;
 
   .ourTeamTitle {
     text-align: center;


### PR DESCRIPTION
Hey Louis!

These are to exclude duplicated `Footer` in `AboutPage` and some necessary padding after `TeamMembers` section.